### PR TITLE
fix: OpenCerts capitalisation

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -38,7 +38,7 @@ class HomeSplash extends React.Component {
     const ProjectTitle = props => (
       <h2 className="projectTitle">
         <span className="title-orange">Open</span>
-        <span className="title-blue">certs</span>
+        <span className="title-blue">Certs</span>
         <small>{props.tagline}</small>
       </h2>
     );


### PR DESCRIPTION
Opencerts should be stylised as OpenCerts, for branding consistency.

#hacktoberfest #oneletterchange jks