### PR TITLE
docs: remove any links to registry page

### DIFF
--- a/docs/multi-issuer.md
+++ b/docs/multi-issuer.md
@@ -70,7 +70,7 @@ This means that the document is considered not revoked as long as none of the is
 
 The issuer identity will be valid for the document, if **at least** one of the following condition is fulfilled:
 
-1. One of the issuer is in the [registry](/registry). Every issuer can be in the registry, but one is enough.
+1. One of the issuer is in the registry. Every issuer can be in the registry, but one is enough.
 1. If no issuer is in the registry, then all issuers must have their identity verified, using any mechanism available from [OpenAttestation](https://www.openattestation.com/docs/docs-section/how-does-it-work/issuance-identity/).
 
 In the event the above conditions are not fulfilled, then the issuers identity will not be valid.

--- a/website/blog/2020-03-13-new-doc.md
+++ b/website/blog/2020-03-13-new-doc.md
@@ -21,7 +21,6 @@ One might be confuse to understand the difference between OpenAttestation and Op
 In OpenCerts documentation we will then focus only on what's specific to OpenCerts:
 
 - [How to create valid OpenCerts transcripts?](/docs/transcripts)
-- [How does OpenCerts registry works?](/docs/registry)
 - [OpenCerts verifiers.](/docs/verifier)
 - [OpenCerts verify API.](/docs/api/verify)
 - [Suggestion to perform live transcripts.](/docs/api/status)

--- a/website/blog/2020-11-17-transcript-2.1.md
+++ b/website/blog/2020-11-17-transcript-2.1.md
@@ -25,12 +25,6 @@ We added support for skills in [the latest version of OpenCerts transcripts sche
 
 You can add as many skills as needed. You can find a [full example here](https://raw.githubusercontent.com/OpenCerts/open-certificate/master/schema/2.1/example.json)
 
-### Registry page
-
-We have redesigned the [OpenCerts registry page](https://dev.opencerts.io/registry). Information of registry are collated by institution (some institution may own multiplie document store). If you need to contact an institution about your OpenCerts you can click on the details or search using the document store from your certificate.
-
-![Registry page](/img/docs/blog/2020-11-17/registry_page.png)
-
 ### Migration legacy to new renderer
 
 In order to help more institution to adopt the decentralized architecture of OpenCerts v2, we have created a [guide](/docs/migrations/migrate_renderer) to help early adopter to migrate from the legacy render to the decentralized renderer.


### PR DESCRIPTION
**Context**
- Registry has been dissolved
- Information about the registry has also been archived/removed in #129 and OpenCerts/opencerts-website/pull/626

**What does this PR do?**
- Remove any remnants/links to the registry page 